### PR TITLE
send message with key

### DIFF
--- a/src/main/java/org/apache/flume/sink/pulsar/PulsarSink.java
+++ b/src/main/java/org/apache/flume/sink/pulsar/PulsarSink.java
@@ -203,7 +203,7 @@ public class PulsarSink extends AbstractSink implements Configurable, BatchSizeS
                 } else {
                     counter.incrementBatchCompleteCount();
                 }
-                producer.send(serializeEvent(event, useAvroEventFormat));
+                producer.newMessage().key(event.getHeaders().get("key")).value(serializeEvent(event, useAvroEventFormat)).send();
             }
             transaction.commit();
         } catch (Exception ex) {


### PR DESCRIPTION
Referring to [Flume-Kafka-Sink](https://github.com/apache/flume/blob/7d3396f26dc1541e9d2a540d50d15a15c38acb74/flume-ng-sinks/flume-ng-kafka-sink/src/main/java/org/apache/flume/sink/kafka/KafkaSink.java#L221), the "key" of message is necessary when [routing pulsar message](http://pulsar.apache.org/docs/en/concepts-messaging/#routing-modes).